### PR TITLE
Use `handle` as well to check for freshness. Implement `createHandle` me...

### DIFF
--- a/fields/field.multilingual_textbox.php
+++ b/fields/field.multilingual_textbox.php
@@ -73,7 +73,7 @@
 
 			if( $this->isHandleLocked($handle, $entry_id, $lang_code) ){
 				if( $this->isHandleFresh($handle, $value, $entry_id, $lang_code) ){
-					return $this->getCurrentHandle($entry_id);
+					return $this->getCurrentHandle($entry_id, $lang_code);
 				}
 
 				else{
@@ -86,6 +86,23 @@
 			}
 
 			return $handle;
+		}
+
+		public function getCurrentHandle($entry_id, $lang_code){
+			return Symphony::Database()->fetchVar('handle', 0, sprintf(
+				"
+					SELECT
+						f.`handle-%s`
+					FROM
+						`tbl_entries_data_%s` AS f
+					WHERE
+						f.entry_id = '%s'
+					LIMIT 1
+				",
+				$lang_code,
+				$this->get('id'),
+				$entry_id
+			));
 		}
 
 		public function isHandleLocked($handle, $entry_id, $lang_code){
@@ -115,10 +132,12 @@
 					WHERE
 						f.entry_id = '%s'
 						AND f.`value-%s` = '%s'
+						AND f.`handle-%s` = '%s'
 					LIMIT 1
 				",
-				$this->get('id'), $entry_id, $lang_code,
-				$this->cleanValue(General::sanitize($value))
+				$this->get('id'), $entry_id,
+				$lang_code, $this->cleanValue(General::sanitize($value)),
+				$lang_code, $this->cleanValue(General::sanitize($handle))
 			));
 		}
 


### PR DESCRIPTION
...thod
1. Use the handle to check for freshness. [Prevents things like this from happening.](https://github.com/rowan-lewis/textboxfield/pull/11)
2. Implemented the `createHandle` method for proper Handle creation. Before this fix, it wasn't creating the unique handles as it should.
