### PR TITLE
Use Author's language first.

### DIFF
--- a/fields/field.multilingual_textbox.php
+++ b/fields/field.multilingual_textbox.php
@@ -473,7 +473,11 @@
 		}
 
 		public function prepareTableValue($data, XMLElement $link = null){
-			$lang_code = FLang::getLangCode();
+			$lang_code = Lang::get();
+
+			if( !FLang::validateLangCode($lang_code) ){
+				$lang_code = FLang::getLangCode();
+			}
 
 			// If value is empty for this language, load value from main language
 			if( $this->get('def_ref_lang') == 'yes' && $data['value-'.$lang_code] === '' ){


### PR DESCRIPTION
In `prepareTableValue`, try to use Author language first, and after that try the main language.

It's really odd to see values both in English (the dev language) and whatever the main language is ( != English).

What do you think?
