### PR TITLE
Fix filtering by isolating private $where.

### DIFF
--- a/fields/field.multilingual_textbox.php
+++ b/fields/field.multilingual_textbox.php
@@ -525,12 +525,16 @@
 		/*------------------------------------------------------------------------------------------------*/
 
 		public function buildDSRetrivalSQL($data, &$joins, &$where, $andOperation = false){
-			parent::buildDSRetrivalSQL($data, $joins, $where, $andOperation);
+			$multi_where = '';
+
+			parent::buildDSRetrivalSQL($data, $joins, $multi_where, $andOperation);
 
 			$lc = FLang::getLangCode();
 
-			$where = str_replace('.value', ".`value-{$lc}`", $where);
-			$where = str_replace('.handle', ".`handle-{$lc}`", $where);
+			$multi_where = str_replace('.value', ".`value-{$lc}`", $multi_where);
+			$multi_where = str_replace('.handle', ".`handle-{$lc}`", $multi_where);
+
+			$where .= $multi_where;
 
 			return true;
 		}


### PR DESCRIPTION
If I set a filter on a field (eg. `checkbox`), save the DS, then set a filter on `Multilingual TB`, an SQL error will be thrown because in current implementation of filtering the `value` and `handle` fields are replaced in the entire `$where` query.

This fix isolates the replacement to only the `$where` from the field, leaving the previous SQL intact.

Thanks!
