### PR TITLE
Fixed table column types

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -330,9 +330,9 @@
 							Symphony::Database()->query(sprintf("
 								ALTER TABLE `%s`
 									ADD COLUMN `handle-{$lc}` varchar(255) default NULL,
-									ADD COLUMN `value-{$lc}` int(11) unsigned NULL,
-									ADD COLUMN `value_formatted-{$lc}` varchar(255) default NULL,
-									ADD COLUMN `word_count-{$lc}` varchar(50) default NULL;",
+									ADD COLUMN `value-{$lc}` text default NULL,
+									ADD COLUMN `value_formatted-{$lc}` text default NULL,
+									ADD COLUMN `word_count-{$lc}` int(11) default NULL;",
 								$entries_table));
 						}
 					}


### PR DESCRIPTION
After saving the preferences of the multilingual_field, some column types are wrong.
- `value-{$lc}` and `value_formatted-{$lc}` have to be of the type `text`
- `word_count` has to be an `int(11)`
