### PR TITLE
Fixed unique handle value for languages.

### DIFF
--- a/fields/field.multilingual_textbox.php
+++ b/fields/field.multilingual_textbox.php
@@ -67,7 +67,7 @@
 		/*------------------------------------------------------------------------------------------------*/
 
 		public function createHandle($value, $entry_id, $lang_code = null){
-			if( FLang::validateLangCode($lang_code) ) $lang_code = FLang::getLangCode();
+			if( !FLang::validateLangCode($lang_code) ) $lang_code = FLang::getLangCode();
 
 			$handle = Lang::createHandle(strip_tags(html_entity_decode($value)));
 


### PR DESCRIPTION
Previous to this fix all values for handles would be compared to `main_lang` value.

With the patch the field correctly compares `en` with `en` and `fr` with `fr` not `en` with `fr` and whatever (`fr` being main language).
