### PR TITLE
Set overflow from tab-panel

### DIFF
--- a/assets/multilingual_field.publish.css
+++ b/assets/multilingual_field.publish.css
@@ -1,3 +1,6 @@
+.field-multilingual_textbox .tab-panel{
+	overflow: hidden;
+}
 .field-multilingual_textbox .size-small {
 	height: 5em;
 }


### PR DESCRIPTION
Tab-panel renders a horizontal scrollbar in Chrome (OSX). This prevents it.
