### PR TITLE
Fix for Textbox field version 2.3.2

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -222,7 +222,7 @@
 					$page->addScriptToHead(URL.'/extensions/'.MTB_GROUP.'/assets/'.MTB_GROUP.'.publish.js');
 				}
 
-				if( $type === self::SETTING_HEADERS ){
+				if( $type === self::FILTER_HEADERS ){
 					$page->addStylesheetToHead(URL.'/extensions/textboxfield/assets/textboxfield.settings.css', 'screen');
 				}
 


### PR DESCRIPTION
Fixed the constant name that has been renamed in textboxfield 2.3.2

This breaks the compatibility with previous version of the textbox field, but is needed from now on.
